### PR TITLE
accelos.commands.json for demo

### DIFF
--- a/accelos.commands.json
+++ b/accelos.commands.json
@@ -1,47 +1,52 @@
 {
   "// This file defines command options for the Gemini CLI Accelos integration": "",
   "// Each command defines an option name, command, and arguments": "",
-
+  
   "commands": [
+    {
+      "name": "ui",
+      "description": "Open AccelOS UI",
+      "command": "./start_servers.sh",
+      "arguments": [],
+      "options": {
+      }
+    },
     {
       "name": "init",
       "description": "Initialize a new Accelos project or workspace",
-      "command": "../a0/scripts/agentic-ekg.sh",
-      "arguments": [
-        "--workflow",
-        "ekg_generation",
-        "--repo-path",
-        ".",
-        "--output-dir",
-        "./.accelos/ekg"
-      ],
-      "options": {}
+      "command": "scripts/static-ekg.sh",
+      "arguments": [],
+      "options": {
+      }
     },
     {
-      "name": "gen-guardrails",
+      "name": "gen-guardrails", 
       "description": "Generate guardrails for the current project",
       "command": "a0",
       "arguments": ["gen-guardrails"],
       "options": {
-        "env": {}
+        "env": {
+        }
       }
     },
     {
       "name": "check-guardrails",
       "description": "Check code against the guardrails deterministically",
-      "command": "./sdlc-linter",
+      "command": "./sdlc-linter", 
       "arguments": ["analyze-git-diff"],
       "options": {
-        "env": {}
+        "env": {
+        }
       }
     },
     {
       "name": "install-pre-commit-hook",
       "description": "Install the check-guardrails as pre-commit hook",
-      "command": "install-precommit.sh",
+      "command": "install-precommit.sh", 
       "arguments": [],
       "options": {
-        "env": {}
+        "env": {
+        }
       }
     }
   ]


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

---

<!-- mesa-description-start -->
## TL;DR
Added a new `ui` command and simplified the existing `init` command in `accelos.commands.json`, primarily for demo purposes.

## Why we made these changes
To enable direct launching of the AccelOS UI via a dedicated command and to streamline the `init` process by switching to a more static EKG script, likely for improved stability or demo environments.

## What changed?
- `accelos.commands.json`:
    - Introduced a new `ui` command for launching the AccelOS UI.
    - Modified the `init` command: changed its execution script from `agentic-ekg.sh` to `static-ekg.sh` and removed arguments.
    - Applied minor formatting changes.

## Validation
- Verify the new `ui` command successfully launches the AccelOS UI.
- Confirm the `init` command executes correctly with the new `static-ekg.sh` script.
- Test command functionality across various environments (npm, npx, Docker) and operating systems (macOS, Windows, Linux) as per the testing matrix.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/accelos/settings/pull-requests)_</sup>
<!-- mesa-description-end -->